### PR TITLE
Fix config and clean up controllers

### DIFF
--- a/src/modules/transaction/transactionModule.ts
+++ b/src/modules/transaction/transactionModule.ts
@@ -1,6 +1,6 @@
 // modules/transaction/transactionModule.ts
 import { CreateTransactionUseCase } from './application/createTransaction';
-import { GetTransactionsUseCase } from './application/getTransactions';;
+import { GetTransactionsUseCase } from './application/getTransactions';
 import { NotionRepository } from './infrastructure/notionRepository';
 import { NotionService } from '../../infrastructure/services/notionService';
 

--- a/src/modules/voiceProcessing/voiceProcessingController.ts
+++ b/src/modules/voiceProcessing/voiceProcessingController.ts
@@ -1,6 +1,5 @@
 import express, { Request, Response } from 'express';
 import multer from 'multer';
-import fs from 'fs';
 import { processVoiceInput, processTextInput } from './voiceProcessingService';
 
 const router = express.Router();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
## Summary
- load Node types in tsconfig
- remove unused `fs` import in `voiceProcessingController`
- clean up `transactionModule` import

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684582d1b37c8330b6eba07d26f4068f