### PR TITLE
Refactor analytics service to depend on repository interface

### DIFF
--- a/src/modules/transaction/application/analyticsService.ts
+++ b/src/modules/transaction/application/analyticsService.ts
@@ -1,9 +1,9 @@
-import { NotionRepository } from "../infrastructure/notionRepository";
+import { TransactionRepository } from "../domain/transactionRepository";
 
 export class AnalyticsService {
-    private repository: NotionRepository;
+    private repository: TransactionRepository;
 
-    constructor(repository: NotionRepository) {
+    constructor(repository: TransactionRepository) {
         this.repository = repository;
     }
 

--- a/src/modules/transaction/interfaces/transactionController.ts
+++ b/src/modules/transaction/interfaces/transactionController.ts
@@ -3,15 +3,11 @@ import { Transaction } from './../domain/transactionEntity';
 import { Router } from 'express';
 import { TransactionModule } from '../transactionModule';
 import { AnalyticsService } from '../application/analyticsService';
-import { NotionRepository } from '../infrastructure/notionRepository';
-import { NotionService } from '../../../infrastructure/services/notionService';
 
 
 const router = Router();
 
-const notionService = new NotionService();
-const notionRepository = new NotionRepository(notionService);
-const analyticsService = new AnalyticsService(notionRepository);
+const analyticsService = new AnalyticsService(TransactionModule.transactionRepository);
 
 router.get('/analytics', async (req, res) => {
     try {

--- a/src/modules/transaction/transactionModule.ts
+++ b/src/modules/transaction/transactionModule.ts
@@ -3,9 +3,10 @@ import { CreateTransactionUseCase } from './application/createTransaction';
 import { GetTransactionsUseCase } from './application/getTransactions';
 import { NotionRepository } from './infrastructure/notionRepository';
 import { NotionService } from '../../infrastructure/services/notionService';
+import { TransactionRepository } from './domain/transactionRepository';
 
 export class TransactionModule {
-  public static transactionRepository = new NotionRepository(new NotionService()); // Можно заменить на другую реализацию
+  public static transactionRepository: TransactionRepository = new NotionRepository(new NotionService()); // Можно заменить на другую реализацию
 
   static getCreateTransactionUseCase(): CreateTransactionUseCase {
     return new CreateTransactionUseCase(this.transactionRepository);


### PR DESCRIPTION
## Summary
- refactor `AnalyticsService` to accept `TransactionRepository`
- wire up `TransactionRepository` through `TransactionModule`
- use the module repository in `transactionController`

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68458e94f8788330aa42309ab282169b