### PR TITLE
Centralize dotenv config

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,8 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
+export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import express, { Request } from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
-import 'dotenv/config'
+import './config'
 
 import transactionRoutes from './modules/transaction/interfaces/transactionController';
 import voiceProcessingRoutes from './modules/voiceProcessing/voiceProcessingController';

--- a/src/infrastructure/services/notionService.ts
+++ b/src/infrastructure/services/notionService.ts
@@ -1,15 +1,14 @@
 import { Transaction } from '../../modules/transaction/domain/transactionEntity';
 import { Client } from '@notionhq/client';
-import dotenv from 'dotenv';
-dotenv.config();
+import { NOTION_API_KEY, NOTION_DATABASE_ID } from "../../config";
 
 export class NotionService {
     private notion: Client;
     private databaseId: string;
 
     constructor() {
-        this.notion = new Client({ auth: process.env.NOTION_API_KEY });
-        this.databaseId = process.env.NOTION_DATABASE_ID || '';  // Здесь должен быть ID базы данных в Notion
+        this.notion = new Client({ auth: NOTION_API_KEY });
+        this.databaseId = NOTION_DATABASE_ID;
     }
 
     async saveTransaction(transaction: Transaction): Promise<void> {

--- a/src/modules/voiceProcessing/textProcessingService.ts
+++ b/src/modules/voiceProcessing/textProcessingService.ts
@@ -1,10 +1,8 @@
 import { OpenAI } from "openai";
 import { ChatCompletionMessageParam } from "openai/resources/chat";
-import dotenv from "dotenv";
+import { OPENAI_API_KEY } from "../../config";
 
-dotenv.config();
-
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
 export async function analyzeSpending(text: string): Promise<{ amount: number; category: string; type: "income" | "expense" }> {
     try {

--- a/src/modules/voiceProcessing/voiceProcessingService.ts
+++ b/src/modules/voiceProcessing/voiceProcessingService.ts
@@ -1,16 +1,15 @@
 import { OpenAI } from "openai";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
+import { OPENAI_API_KEY } from "../../config";
 import { analyzeSpending } from "./textProcessingService";
 import { NotionService } from "../../infrastructure/services/notionService";
 import { NotionRepository } from "../transaction/infrastructure/notionRepository";
 import { CreateTransactionUseCase } from "../transaction/application/createTransaction";
 import { Transaction } from "../transaction/domain/transactionEntity";
 
-dotenv.config();
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 const notionService = new NotionService();
 const notionRepository = new NotionRepository(notionService);
 const createTransactionUseCase = new CreateTransactionUseCase(notionRepository);


### PR DESCRIPTION
## Summary
- create config module to load environment variables
- use config in Notion and voice processing services
- initialize app using the new config loader

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68458ec4d874833086dc60dc4494c679