### PR TITLE
Fix OpenAI import

### DIFF
--- a/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
+++ b/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
@@ -1,4 +1,4 @@
-import { OpenAI } from 'openai';
+import OpenAI from 'openai';
 import fs from 'fs';
 import { ChatCompletionMessageParam } from 'openai/resources/chat';
 


### PR DESCRIPTION
## Summary
- update OpenAI service import to use default export

## Testing
- `npm test` *(fails: Cannot find name 'describe')*

------
https://chatgpt.com/codex/tasks/task_e_68459eba47948330bd893bdca950e2dc