### PR TITLE
Fix tsconfig for jest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["node"],
+    "types": ["node", "jest"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
@@ -100,8 +100,9 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "src/**/*.ts"
-  ], // Включить все файлы TypeScript в папке src.
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ], // Включить все файлы TypeScript в папке src и тесты.
   "exclude": [
     "node_modules",
     "dist"


### PR DESCRIPTION
## Summary
- include jest types
- compile tests under tsconfig

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a047db5083308f9783edbb429373