### PR TITLE
Fix build by excluding tests from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,9 +100,8 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "src/**/*.ts",
-    "tests/**/*.ts"
-  ], // Включить все файлы TypeScript в папке src и тесты.
+    "src/**/*.ts"
+  ], // Включить все файлы TypeScript в папке src.
   "exclude": [
     "node_modules",
     "dist"


### PR DESCRIPTION
## Summary
- adjust tsconfig to only include source files
- keep `rootDir` at `src` so built files output to `dist/`

## Testing
- `npm run build`
- `npm run start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845a6fd8b488330aa6e59d5dd454660