### PR TITLE
Integrate Telegram bot and user tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npm install
 OPENAI_API_KEY=your_openai_key
 NOTION_API_KEY=your_notion_key
 NOTION_DATABASE_ID=your_notion_database_id
+TG_BOT_API_KEY=your_telegram_bot_key
 ```
 
 ## Build and Run

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "^4.21.1",
     "multer": "^1.4.5-lts.2",
     "openai": "^4.89.0",
+    "telegraf": "^4.12.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.3"
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,4 +5,5 @@ dotenv.config();
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
 export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
+export const TG_BOT_API_KEY = process.env.TG_BOT_API_KEY || '';
 

--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -1,0 +1,60 @@
+import { Telegraf } from 'telegraf';
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+import { TG_BOT_API_KEY } from '../../config';
+import { VoiceProcessingModule } from '../../modules/voiceProcessing/voiceProcessingModule';
+
+function downloadFile(url: string, dest: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https.get(url, response => {
+      response.pipe(file);
+      file.on('finish', () => file.close(() => resolve(dest)));
+    }).on('error', err => {
+      fs.unlink(dest, () => reject(err));
+    });
+  });
+}
+
+export function startTelegramBot(module: VoiceProcessingModule) {
+  if (!TG_BOT_API_KEY) {
+    console.warn('TG_BOT_API_KEY is not set, Telegram bot disabled');
+    return;
+  }
+
+  const bot = new Telegraf(TG_BOT_API_KEY);
+
+  bot.on('text', async ctx => {
+    const userId = String(ctx.from?.id ?? 'unknown');
+    const userName = ctx.from?.username || ctx.from?.first_name;
+    const text = ctx.message.text;
+    try {
+      await module.getProcessTextInputUseCase().execute(text, userId, userName);
+      await ctx.reply('Transaction saved');
+    } catch (err) {
+      console.error('Error handling text message:', err);
+      await ctx.reply('Failed to process message');
+    }
+  });
+
+  bot.on('voice', async ctx => {
+    const userId = String(ctx.from?.id ?? 'unknown');
+    const userName = ctx.from?.username || ctx.from?.first_name;
+    const fileLink = await ctx.telegram.getFileLink(ctx.message.voice.file_id);
+    const filePath = path.join('downloads', ctx.message.voice.file_id);
+    try {
+      await downloadFile(fileLink.href, filePath);
+      await module.getProcessVoiceInputUseCase().execute({ filePath, userId, userName });
+      await ctx.reply('Transaction saved');
+    } catch (err) {
+      console.error('Error handling voice message:', err);
+      await ctx.reply('Failed to process voice message');
+    } finally {
+      fs.unlink(filePath, () => {});
+    }
+  });
+
+  bot.launch();
+  console.log('Telegram bot started');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,20 @@
 import './config';
 import { buildServer } from './framework/express/expressServer';
+import { OPENAI_API_KEY, NOTION_API_KEY, NOTION_DATABASE_ID } from './config';
+import { NotionService } from './infrastructure/services/notionService';
+import { TransactionModule } from './modules/transaction/transactionModule';
+import { OpenAITranscriptionService } from './modules/voiceProcessing/infrastructure/openAITranscriptionService';
+import { VoiceProcessingModule } from './modules/voiceProcessing/voiceProcessingModule';
+import { startTelegramBot } from './framework/telegram/telegramBot';
 
 const app = buildServer();
 const port = process.env.PORT || 3000;
+
+const notionService = new NotionService(NOTION_API_KEY, NOTION_DATABASE_ID);
+const transactionModule = TransactionModule.create(notionService);
+const openAIService = new OpenAITranscriptionService(OPENAI_API_KEY);
+const voiceModule = new VoiceProcessingModule(openAIService, transactionModule);
+startTelegramBot(voiceModule);
 
 app.listen(port, () => {
     console.log(`Server running on port ${port}`);

--- a/src/infrastructure/services/notionService.ts
+++ b/src/infrastructure/services/notionService.ts
@@ -35,6 +35,20 @@ export class NotionService {
                 Type: {
                     select: { name: transaction.type === 'income' ? 'Income' : 'Expense' },
                 },
+                UserId: {
+                    rich_text: [
+                        {
+                            text: { content: transaction.userId },
+                        },
+                    ],
+                },
+                UserName: {
+                    rich_text: [
+                        {
+                            text: { content: transaction.userName || transaction.userId },
+                        },
+                    ],
+                },
             },
         });
     }
@@ -51,6 +65,8 @@ export class NotionService {
                 description: page.properties.Description.title[0].text.content,  // Описание
                 amount: page.properties.Amount.number,   // Сумма
                 type: page.properties.Type.select.name === 'Income' ? 'income' : 'expense', // Тип транзакции
+                userId: page.properties.UserId.rich_text[0]?.plain_text || '',
+                userName: page.properties.UserName?.rich_text[0]?.plain_text,
             }));
         } catch (error: any) {
             console.log(error);

--- a/src/modules/transaction/domain/transactionEntity.ts
+++ b/src/modules/transaction/domain/transactionEntity.ts
@@ -4,4 +4,6 @@ export interface Transaction {
     description: string;
     amount: number;
     type: 'income' | 'expense';  // Тип транзакции
+    userId: string;
+    userName?: string;
 }

--- a/src/modules/transaction/interfaces/transactionController.ts
+++ b/src/modules/transaction/interfaces/transactionController.ts
@@ -27,14 +27,14 @@ export function createTransactionRouter(
   });
 
   router.post('/', async (req, res) => {
-    const { date, category, description, amount, type } = req.body as Transaction;
-    if (!date || !category || !description || !amount || !type) {
+    const { date, category, description, amount, type, userId, userName } = req.body as Transaction;
+    if (!date || !category || !description || !amount || !type || !userId) {
       res.status(400).json({ error: 'All fields are required' });
       return;
     }
 
     try {
-      const transaction = { date, category, description, amount, type };
+      const transaction = { date, category, description, amount, type, userId, userName };
       await createUseCase.execute(transaction);
       res.status(201).send('Transaction created');
     } catch (error: any) {

--- a/src/modules/voiceProcessing/application/processTextInput.ts
+++ b/src/modules/voiceProcessing/application/processTextInput.ts
@@ -9,7 +9,7 @@ export class ProcessTextInputUseCase {
         private createTransactionUseCase: CreateTransactionUseCase
     ) {}
 
-    async execute(text: string): Promise<ProcessedTransaction> {
+    async execute(text: string, userId: string, userName?: string): Promise<ProcessedTransaction> {
         const { amount, category, type } = await this.openAIService.analyzeText(text);
 
         const transaction: Transaction = {
@@ -18,6 +18,8 @@ export class ProcessTextInputUseCase {
             description: text,
             amount,
             type,
+            userId,
+            userName,
         };
 
         await this.createTransactionUseCase.execute(transaction);

--- a/src/modules/voiceProcessing/application/processVoiceInput.ts
+++ b/src/modules/voiceProcessing/application/processVoiceInput.ts
@@ -25,6 +25,8 @@ export class ProcessVoiceInputUseCase {
             description: recognizedText,
             amount,
             type,
+            userId: input.userId,
+            userName: input.userName,
         };
 
         await this.createTransactionUseCase.execute(transaction);

--- a/src/modules/voiceProcessing/domain/voiceInput.ts
+++ b/src/modules/voiceProcessing/domain/voiceInput.ts
@@ -1,3 +1,5 @@
 export interface VoiceInput {
     filePath: string;
+    userId: string;
+    userName?: string;
 }

--- a/src/modules/voiceProcessing/voiceProcessingController.ts
+++ b/src/modules/voiceProcessing/voiceProcessingController.ts
@@ -11,13 +11,17 @@ export function createVoiceProcessingRouter(
   const upload = multer({ dest: 'uploads/' });
 
   router.post('/voice-input', upload.single('audio'), async (req: Request, res: Response) => {
-    if (!req.file) {
-      res.status(400).json({ error: 'No audio file uploaded' });
+    if (!req.file || !req.body.userId) {
+      res.status(400).json({ error: 'Audio file and userId are required' });
       return;
     }
 
     try {
-      const result = await voiceUseCase.execute({ filePath: req.file.path });
+      const result = await voiceUseCase.execute({
+        filePath: req.file.path,
+        userId: req.body.userId,
+        userName: req.body.userName,
+      });
       res.json(result);
     } catch (error) {
       console.error('Error processing voice input:', error);
@@ -26,13 +30,13 @@ export function createVoiceProcessingRouter(
   });
 
   router.post('/text-input', async (req: Request, res: Response) => {
-    if (!req.body.text) {
-      res.status(400).json({ error: 'No text provided' });
+    if (!req.body.text || !req.body.userId) {
+      res.status(400).json({ error: 'Text and userId are required' });
       return;
     }
 
     try {
-      const result = await textUseCase.execute(req.body.text);
+      const result = await textUseCase.execute(req.body.text, req.body.userId, req.body.userName);
       res.json(result);
     } catch (error) {
       console.error('Error processing text input:', error);

--- a/tests/createTransaction.test.ts
+++ b/tests/createTransaction.test.ts
@@ -9,7 +9,8 @@ describe('CreateTransactionUseCase', () => {
       category: 'Food',
       description: 'Lunch',
       amount: 10,
-      type: 'expense'
+      type: 'expense',
+      userId: 'user1'
     };
 
     const save = jest.fn().mockResolvedValue(undefined);

--- a/tests/getTransactions.test.ts
+++ b/tests/getTransactions.test.ts
@@ -5,7 +5,7 @@ import { TransactionRepository } from '../src/modules/transaction/domain/transac
 describe('GetTransactionsUseCase', () => {
   it('returns data from repository', async () => {
     const data: Transaction[] = [
-      { date: '2024-01-01', category: 'Food', description: 'Lunch', amount: 10, type: 'expense' }
+      { date: '2024-01-01', category: 'Food', description: 'Lunch', amount: 10, type: 'expense', userId: 'user1' }
     ];
 
     const repo: TransactionRepository = { save: jest.fn(), getAll: jest.fn().mockResolvedValue(data) };

--- a/tests/processTextInput.test.ts
+++ b/tests/processTextInput.test.ts
@@ -16,7 +16,7 @@ describe('ProcessTextInputUseCase', () => {
     } as unknown as CreateTransactionUseCase;
 
     const useCase = new ProcessTextInputUseCase(openAIService, createTransactionUseCase);
-    const result = await useCase.execute('test');
+    const result = await useCase.execute('test', 'user1');
 
     expect(createTransactionUseCase.execute).toHaveBeenCalled();
     expect(result).toEqual({ text: 'test', amount: 5, category: 'Food', type: 'expense' });


### PR DESCRIPTION
## Summary
- add `TG_BOT_API_KEY` configuration value
- support `userId` on transactions and voice inputs
- save and load `userId` in Notion service
- require `userId` in transaction and voice controllers
- implement Telegram bot adapter
- start Telegram bot alongside Express server
- document Telegram key in README
- store and display Telegram `userName` when available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845dc11d6148330a4c48e3f9704cb04