### PR TITLE
Implement OpenAIChatService

### DIFF
--- a/src/infrastructure/openai/OpenAIChatService.ts
+++ b/src/infrastructure/openai/OpenAIChatService.ts
@@ -1,0 +1,33 @@
+import OpenAI from 'openai';
+import { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat';
+import { TransactionDTO } from '../../core/dto/TransactionDTO';
+
+export class OpenAIChatService {
+    private readonly openai: OpenAI;
+    private readonly tools: ChatCompletionTool[];
+
+    constructor(apiKey: string, tools: ChatCompletionTool[]) {
+        this.openai = new OpenAI({ apiKey });
+        this.tools = tools;
+    }
+
+    async extractTransaction(prompt: string): Promise<TransactionDTO> {
+        const messages: ChatCompletionMessageParam[] = [
+            { role: 'user', content: prompt }
+        ];
+
+        const response = await this.openai.chat.completions.create({
+            model: 'gpt-4o-mini',
+            messages,
+            tools: this.tools,
+        });
+
+        const toolCall = response.choices[0]?.message.tool_calls?.[0];
+        if (!toolCall) {
+            throw new Error('No tool call returned');
+        }
+
+        return TransactionDTO.fromRaw(toolCall.function.arguments);
+    }
+}
+

--- a/tests/openaiChatService.test.ts
+++ b/tests/openaiChatService.test.ts
@@ -1,0 +1,49 @@
+import OpenAI from 'openai';
+import { OpenAIChatService } from '../src/infrastructure/openai/OpenAIChatService';
+import { TransactionDTO } from '../src/core/dto/TransactionDTO';
+
+jest.mock('openai');
+
+describe('OpenAIChatService', () => {
+  it('parses tool_call into TransactionDTO', async () => {
+    const createMock = jest.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              {
+                function: {
+                  name: 'add_transaction',
+                  arguments: JSON.stringify({
+                    amount: 20,
+                    currency: 'USD',
+                    type: 'expense',
+                    account: 'cash',
+                    category: 'food'
+                  })
+                }
+              }
+            ]
+          }
+        }
+      ]
+    });
+
+    (OpenAI as unknown as jest.Mock).mockImplementation(() => ({
+      chat: { completions: { create: createMock } }
+    }));
+
+    const tools: any[] = [];
+    const service = new OpenAIChatService('key', tools);
+    const dto = await service.extractTransaction('sample');
+
+    expect(createMock).toHaveBeenCalledWith({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'sample' }],
+      tools
+    });
+    expect(dto).toBeInstanceOf(TransactionDTO);
+    expect(dto.amount).toBe(20);
+    expect(dto.currency).toBe('USD');
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAIChatService to call OpenAI chat completions and extract a TransactionDTO
- cover OpenAIChatService with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cd97a77ec8330a507f191ef2bd4df