### PR TITLE
Implement OpenAIModerationService

### DIFF
--- a/src/infrastructure/openai/OpenAIModerationService.ts
+++ b/src/infrastructure/openai/OpenAIModerationService.ts
@@ -1,0 +1,16 @@
+import OpenAI from 'openai';
+
+export class OpenAIModerationService {
+    private readonly openai: OpenAI;
+
+    constructor(openai: OpenAI) {
+        this.openai = openai;
+    }
+
+    async isAllowed(text: string): Promise<boolean> {
+        const response = await this.openai.moderations.create({ input: text });
+        const blocked = (response.results[0] as any)?.blocked;
+        return blocked === false || blocked === undefined;
+    }
+}
+

--- a/tests/openaiModerationService.test.ts
+++ b/tests/openaiModerationService.test.ts
@@ -1,0 +1,19 @@
+import OpenAI from 'openai';
+import { OpenAIModerationService } from '../src/infrastructure/openai/OpenAIModerationService';
+
+jest.mock('openai');
+jest.mock('axios', () => ({}), { virtual: true });
+describe('OpenAIModerationService', () => {
+  it('returns true when not blocked', async () => {
+    const createMock = jest.fn().mockResolvedValue({ results: [{ blocked: false }] });
+    (OpenAI as unknown as jest.Mock).mockImplementation(() => ({ moderations: { create: createMock } }));
+
+    const client = new OpenAI({ apiKey: 'key' });
+    const service = new OpenAIModerationService(client);
+    const allowed = await service.isAllowed('hello');
+
+    expect(createMock).toHaveBeenCalledWith({ input: 'hello' });
+    expect(allowed).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add OpenAIModerationService using OpenAI SDK
- cover moderation service with unit test mocking axios module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ce304c7448330a23c45b923e7307f