### PR TITLE
Implement OpenAI embedding service

### DIFF
--- a/src/infrastructure/openai/OpenAIEmbeddingService.ts
+++ b/src/infrastructure/openai/OpenAIEmbeddingService.ts
@@ -1,0 +1,19 @@
+import OpenAI from 'openai';
+
+export class OpenAIEmbeddingService {
+    private readonly openai: OpenAI;
+
+    constructor(apiKey: string) {
+        this.openai = new OpenAI({ apiKey });
+    }
+
+    async embed(text: string): Promise<Float32Array> {
+        const response = await this.openai.embeddings.create({
+            model: 'text-embedding-3-small',
+            input: text,
+        });
+        const embedding = response.data[0]?.embedding ?? [];
+        return new Float32Array(embedding);
+    }
+}
+

--- a/tests/openaiEmbeddingService.test.ts
+++ b/tests/openaiEmbeddingService.test.ts
@@ -1,0 +1,19 @@
+import OpenAI from 'openai';
+import { OpenAIEmbeddingService } from '../src/infrastructure/openai/OpenAIEmbeddingService';
+
+jest.mock('openai');
+jest.mock('axios', () => ({}), { virtual: true });
+
+describe('OpenAIEmbeddingService', () => {
+  it('requests embedding and returns Float32Array', async () => {
+    const createMock = jest.fn().mockResolvedValue({ data: [{ embedding: [1, 2] }] });
+    (OpenAI as unknown as jest.Mock).mockImplementation(() => ({ embeddings: { create: createMock } }));
+
+    const service = new OpenAIEmbeddingService('key');
+    const vec = await service.embed('hello');
+
+    expect(createMock).toHaveBeenCalledWith({ model: 'text-embedding-3-small', input: 'hello' });
+    expect(vec).toBeInstanceOf(Float32Array);
+    expect(Array.from(vec)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAIEmbeddingService to request embeddings
- test the embedding service

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ce48af3c48330a2bf452a27ece171