### PR TITLE
Add category vector repository

### DIFF
--- a/src/infrastructure/openai/OpenAIEmbeddingService.ts
+++ b/src/infrastructure/openai/OpenAIEmbeddingService.ts
@@ -1,0 +1,21 @@
+import OpenAI from 'openai';
+
+export class OpenAIEmbeddingService {
+    private readonly openai: OpenAI;
+
+    constructor(apiKey: string) {
+        this.openai = new OpenAI({ apiKey });
+    }
+
+    async embed(text: string): Promise<number[]> {
+        const response = await this.openai.embeddings.create({
+            model: 'text-embedding-3-small',
+            input: text,
+        });
+        const [first] = response.data;
+        if (!first) {
+            throw new Error('No embedding returned');
+        }
+        return first.embedding as unknown as number[];
+    }
+}

--- a/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
+++ b/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
@@ -1,0 +1,51 @@
+import { OpenAIEmbeddingService } from '../../../infrastructure/openai/OpenAIEmbeddingService';
+
+interface CategoryVectorRow {
+    id: number;
+    label: string;
+    embedding: number[];
+}
+
+export class CategoryVectorRepository {
+    constructor(private readonly supabase: any, private readonly embeddingService: OpenAIEmbeddingService) {}
+
+    private static cosineSimilarity(a: number[], b: number[]): number {
+        let dot = 0;
+        let normA = 0;
+        let normB = 0;
+        for (let i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+
+    async findNearest(text: string): Promise<{ label: string; score: number }> {
+        const { data, error } = await this.supabase
+            .from('category_vectors')
+            .select('id,label,embedding');
+
+        if (error) {
+            throw error;
+        }
+        if (!data) {
+            throw new Error('No data returned from Supabase');
+        }
+
+        const embedding = await this.embeddingService.embed(text);
+
+        let bestLabel = '';
+        let bestScore = -Infinity;
+
+        for (const row of data as CategoryVectorRow[]) {
+            const score = CategoryVectorRepository.cosineSimilarity(embedding, row.embedding);
+            if (score > bestScore) {
+                bestScore = score;
+                bestLabel = row.label;
+            }
+        }
+
+        return { label: bestLabel, score: bestScore };
+    }
+}

--- a/tests/categoryVectorRepository.test.ts
+++ b/tests/categoryVectorRepository.test.ts
@@ -1,0 +1,28 @@
+import { CategoryVectorRepository } from '../src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository';
+import { OpenAIEmbeddingService } from '../src/infrastructure/openai/OpenAIEmbeddingService';
+
+describe('CategoryVectorRepository', () => {
+  it('finds nearest label by cosine similarity', async () => {
+    const select = jest.fn().mockResolvedValue({
+      data: [
+        { id: 1, label: 'Food', embedding: [1, 0] },
+        { id: 2, label: 'Rent', embedding: [0, 1] }
+      ],
+      error: null
+    });
+    const from = jest.fn().mockReturnValue({ select });
+    const supabase = { from } as any;
+
+    const embeddingService = {
+      embed: jest.fn().mockResolvedValue([1, 0])
+    } as unknown as OpenAIEmbeddingService;
+
+    const repo = new CategoryVectorRepository(supabase, embeddingService);
+    const result = await repo.findNearest('sample');
+
+    expect(from).toHaveBeenCalledWith('category_vectors');
+    expect(embeddingService.embed).toHaveBeenCalledWith('sample');
+    expect(result.label).toBe('Food');
+    expect(result.score).toBeCloseTo(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAIEmbeddingService to obtain embeddings
- implement CategoryVectorRepository with cosine similarity search
- cover repository with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ce491aa2c8330be48c1e5ddbb9232