### PR TITLE
Implement category vector repository

### DIFF
--- a/src/infrastructure/openai/OpenAIEmbeddingService.ts
+++ b/src/infrastructure/openai/OpenAIEmbeddingService.ts
@@ -1,0 +1,17 @@
+import OpenAI from 'openai';
+
+export class OpenAIEmbeddingService {
+  private openai: OpenAI;
+
+  constructor(apiKey: string) {
+    this.openai = new OpenAI({ apiKey });
+  }
+
+  async getEmbedding(text: string): Promise<number[]> {
+    const response = await this.openai.embeddings.create({
+      model: 'text-embedding-ada-002',
+      input: text,
+    });
+    return response.data[0].embedding as number[];
+  }
+}

--- a/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
+++ b/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
@@ -1,0 +1,50 @@
+import { OpenAIEmbeddingService } from '../../../infrastructure/openai/OpenAIEmbeddingService';
+
+export interface CategoryVector {
+  label: string;
+  embedding: number[];
+}
+
+export class CategoryVectorRepository {
+  constructor(
+    private supabase: any,
+    private embeddingService: OpenAIEmbeddingService
+  ) {}
+
+  private cosineSimilarity(a: number[], b: number[]): number {
+    const dot = a.reduce((sum, val, i) => sum + val * b[i], 0);
+    const magA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+    const magB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+    if (magA === 0 || magB === 0) return 0;
+    return dot / (magA * magB);
+  }
+
+  async findNearest(text: string): Promise<{ label: string; score: number }> {
+    const { data, error } = await this.supabase
+      .from('category_vectors')
+      .select('label, embedding');
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (!data) {
+      throw new Error('No data returned from category_vectors');
+    }
+
+    const queryEmbedding = await this.embeddingService.getEmbedding(text);
+
+    let bestLabel = '';
+    let bestScore = -1;
+
+    for (const row of data as CategoryVector[]) {
+      const score = this.cosineSimilarity(queryEmbedding, row.embedding);
+      if (score > bestScore) {
+        bestScore = score;
+        bestLabel = row.label;
+      }
+    }
+
+    return { label: bestLabel, score: bestScore };
+  }
+}

--- a/tests/categoryVectorRepository.test.ts
+++ b/tests/categoryVectorRepository.test.ts
@@ -1,0 +1,27 @@
+import { CategoryVectorRepository } from '../src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository';
+import { OpenAIEmbeddingService } from '../src/infrastructure/openai/OpenAIEmbeddingService';
+
+describe('CategoryVectorRepository', () => {
+  it('returns label with highest cosine similarity', async () => {
+    const supabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockResolvedValue({
+        data: [
+          { label: 'Food', embedding: [1, 0] },
+          { label: 'Travel', embedding: [0, 1] },
+        ],
+        error: null,
+      }),
+    };
+
+    const embeddingService: OpenAIEmbeddingService = {
+      getEmbedding: jest.fn().mockResolvedValue([1, 0]),
+    } as unknown as OpenAIEmbeddingService;
+
+    const repo = new CategoryVectorRepository(supabase, embeddingService);
+    const result = await repo.findNearest('dummy');
+
+    expect(supabase.from).toHaveBeenCalledWith('category_vectors');
+    expect(result).toEqual({ label: 'Food', score: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAI embedding service
- implement category vector repository for Supabase pgvector table
- provide unit test for category vector repository

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ce62a887c8330ad564beef1e385a4