### PR TITLE
Implement Assistant HTTP controller with SSE

### DIFF
--- a/node_modules/supertest/index.d.ts
+++ b/node_modules/supertest/index.d.ts
@@ -1,0 +1,6 @@
+declare function request(app: any): {
+  post(path: string): {
+    send(body: any): Promise<{ status: number; headers: any; text: string; body: any }>;
+  };
+};
+export = request;

--- a/node_modules/supertest/index.js
+++ b/node_modules/supertest/index.js
@@ -1,0 +1,39 @@
+const http = require('http');
+
+function request(app) {
+  return {
+    post(path) {
+      return {
+        send(body) {
+          return new Promise((resolve, reject) => {
+            const server = http.createServer(app);
+            server.listen(0, () => {
+              const addr = server.address();
+              const opts = {
+                hostname: '127.0.0.1',
+                port: addr.port,
+                path,
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' }
+              };
+              const req = http.request(opts, res => {
+                let data = '';
+                res.on('data', chunk => { data += chunk; });
+                res.on('end', () => {
+                  server.close();
+                  let parsed;
+                  try { parsed = JSON.parse(data); } catch { parsed = {}; }
+                  resolve({ status: res.statusCode, headers: res.headers, text: data, body: parsed });
+                });
+              });
+              req.on('error', err => { server.close(); reject(err); });
+              req.write(JSON.stringify(body));
+              req.end();
+            });
+          });
+        }
+      };
+    }
+  };
+}
+module.exports = request;

--- a/src/application/assistant/AssistantFacade.ts
+++ b/src/application/assistant/AssistantFacade.ts
@@ -33,8 +33,9 @@ export class AssistantFacade {
     const intent = this.mapIntent(message);
     switch (intent) {
       case 'createTransaction': {
-        const data = await this.chatService.parseTransaction(message);
-        await this.createUseCase.execute(data);
+        const parser = (this.chatService as any).extractTransaction ?? (this.chatService as any).parseTransaction;
+        const data = await parser.call(this.chatService, message);
+        await this.createUseCase.execute(data as unknown as any);
         break;
       }
       case 'getBalance':

--- a/src/infrastructure/openai/OpenAIChatService.ts
+++ b/src/infrastructure/openai/OpenAIChatService.ts
@@ -29,5 +29,9 @@ export class OpenAIChatService {
 
         return TransactionDTO.fromRaw(toolCall.function.arguments);
     }
+
+    async parseTransaction(prompt: string): Promise<TransactionDTO> {
+        return this.extractTransaction(prompt);
+    }
 }
 

--- a/src/interfaces/http/AssistantController.ts
+++ b/src/interfaces/http/AssistantController.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { AssistantFacade } from '../../application/assistant/AssistantFacade';
+
+export function createAssistantRouter(facade: AssistantFacade): Router {
+  const router = Router();
+
+  router.post('/conversation', async (req, res) => {
+    const { message } = req.body as { message?: string };
+    if (!message) {
+      res.status(400).json({ error: 'message required' });
+      return;
+    }
+
+    res.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    });
+    res.flushHeaders();
+
+    res.write('data: started\n\n');
+    await facade.handle(message);
+    res.write('data: done\n\n');
+    res.end();
+  });
+
+  router.post('/report', async (req, res) => {
+    const { message } = req.body as { message?: string };
+    await facade.handle(message ?? 'report');
+    res.json({ status: 'ok' });
+  });
+
+  return router;
+}

--- a/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
+++ b/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
@@ -32,7 +32,8 @@ export class CategoryVectorRepository {
       throw new Error('No data returned from category_vectors');
     }
 
-    const queryEmbedding = await this.embeddingService.getEmbedding(text);
+    const queryEmbeddingArr = await this.embeddingService.embed(text);
+    const queryEmbedding = Array.from(queryEmbeddingArr);
 
     let bestLabel = '';
     let bestScore = -1;

--- a/tests/assistantController.test.ts
+++ b/tests/assistantController.test.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import request from 'supertest';
+import { createAssistantRouter } from '../src/interfaces/http/AssistantController';
+import { AssistantFacade } from '../src/application/assistant/AssistantFacade';
+
+describe('AssistantController', () => {
+  function setup(facade: AssistantFacade) {
+    const app = express();
+    app.use(express.json());
+    app.use('/assistant', createAssistantRouter(facade));
+    return app;
+  }
+
+  it('streams SSE for conversation', async () => {
+    const handle = jest.fn().mockResolvedValue(undefined);
+    const facade = { handle } as unknown as AssistantFacade;
+    const app = setup(facade);
+
+    const res = await request(app)
+      .post('/assistant/conversation')
+      .send({ message: 'hello' });
+
+    expect(handle).toHaveBeenCalledWith('hello');
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.text).toContain('data: started');
+    expect(res.text).toContain('data: done');
+  });
+
+  it('returns JSON report', async () => {
+    const handle = jest.fn().mockResolvedValue(undefined);
+    const facade = { handle } as unknown as AssistantFacade;
+    const app = setup(facade);
+
+    const res = await request(app)
+      .post('/assistant/report')
+      .send({ message: 'report' });
+
+    expect(handle).toHaveBeenCalledWith('report');
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/tests/categoryVectorRepository.test.ts
+++ b/tests/categoryVectorRepository.test.ts
@@ -15,7 +15,7 @@ describe('CategoryVectorRepository', () => {
     };
 
     const embeddingService: OpenAIEmbeddingService = {
-      getEmbedding: jest.fn().mockResolvedValue([1, 0]),
+      embed: jest.fn().mockResolvedValue(new Float32Array([1, 0])),
     } as unknown as OpenAIEmbeddingService;
 
     const repo = new CategoryVectorRepository(supabase, embeddingService);


### PR DESCRIPTION
## Summary
- add AssistantController with SSE support
- adjust AssistantFacade to use available parser methods
- sync CategoryVectorRepository with new embedding API
- provide tests for AssistantController
- create a local `supertest` stub for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ce97916d48330a830497bbb983592