### PR TITLE
Implement daily analytics worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npx tsc",
     "serve": "node dist/index.js",
     "dev": "ts-node-dev src/index.ts",
-    "test": "jest"
+    "test": "jest",
+    "analytics": "ts-node src/workers/dailyAnalytics.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/workers/dailyAnalytics.ts
+++ b/src/workers/dailyAnalytics.ts
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import { NotionService } from '../infrastructure/services/notionService';
+import { NotionRepository } from '../modules/transaction/infrastructure/notionRepository';
+import { TransactionRepository } from '../modules/transaction/domain/transactionRepository';
+import { NOTION_API_KEY, NOTION_DATABASE_ID } from '../config';
+
+export async function runDailyAnalytics(
+  repository: TransactionRepository,
+  batchUrl: string,
+  outputDir: string
+): Promise<void> {
+  const all = await repository.getAll();
+  const yesterday = new Date(Date.now() - 86400000);
+  const dateStr = yesterday.toISOString().slice(0, 10);
+  const yesterdayTx = all.filter(t => t.date.startsWith(dateStr));
+
+  const response = await fetch(batchUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(yesterdayTx)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Batch request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(`${outputDir}/${dateStr}.json`, JSON.stringify(data));
+}
+
+(async () => {
+  if (require.main !== module) {
+    return;
+  }
+
+  const notion = new NotionService(NOTION_API_KEY, NOTION_DATABASE_ID);
+  const repo = new NotionRepository(notion);
+  const endpoint = process.env.BATCH_URL || 'http://localhost:3000/batch';
+  const dir = process.env.ANALYTICS_DIR || './analytics';
+
+  try {
+    await runDailyAnalytics(repo, endpoint, dir);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/tests/dailyAnalytics.test.ts
+++ b/tests/dailyAnalytics.test.ts
@@ -1,0 +1,34 @@
+import { runDailyAnalytics } from '../src/workers/dailyAnalytics';
+import { Transaction } from '../src/modules/transaction/domain/transactionEntity';
+import { TransactionRepository } from '../src/modules/transaction/domain/transactionRepository';
+import fs from 'fs/promises';
+
+describe('runDailyAnalytics', () => {
+  it('writes batch results for yesterday', async () => {
+    const date = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const transactions: Transaction[] = [
+      { date, category: 'Food', description: 'lunch', amount: 10, type: 'expense', userId: 'u1' },
+      { date: '2020-01-01', category: 'Other', description: 'old', amount: 5, type: 'expense', userId: 'u1' }
+    ];
+
+    const repo: TransactionRepository = {
+      save: jest.fn(),
+      getAll: jest.fn().mockResolvedValue(transactions)
+    };
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ processed: 1 })
+    });
+    (global as any).fetch = fetchMock;
+
+    const mkdirMock = jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined as any);
+    const writeFileMock = jest.spyOn(fs, 'writeFile').mockResolvedValue(undefined as any);
+
+    await runDailyAnalytics(repo, 'http://svc/batch', '/tmp/out');
+
+    expect(fetchMock).toHaveBeenCalledWith('http://svc/batch', expect.objectContaining({ method: 'POST' }));
+    expect(mkdirMock).toHaveBeenCalledWith('/tmp/out', { recursive: true });
+    expect(writeFileMock).toHaveBeenCalledWith(`/tmp/out/${date}.json`, JSON.stringify({ processed: 1 }));
+  });
+});


### PR DESCRIPTION
## Summary
- add `runDailyAnalytics` worker
- expose `npm run analytics` script
- test daily analytics worker

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685d0dc1ee7083309131230a71a2b4f9