### PR TITLE
Add analytics service with cron

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       - "3000:3000"
     restart: unless-stopped
     command: npm start
+
+  analytics:
+    build: .
+    working_dir: /app
+    command: npm run analytics
+    restart: unless-stopped
+    cron: "0 2 * * *"


### PR DESCRIPTION
## Summary
- update docker-compose to run analytics job on schedule

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_685d10888bb483308b656f25607c3df6