### PR TITLE
Add category vector repo support

### DIFF
--- a/src/modules/transaction/application/createTransaction.ts
+++ b/src/modules/transaction/application/createTransaction.ts
@@ -2,15 +2,25 @@
 
 import { Transaction } from '../domain/transactionEntity';
 import { TransactionRepository } from '../domain/transactionRepository';
+import { CategoryVectorRepository } from '../domain/categoryVectorRepository';
 
 export class CreateTransactionUseCase {
     private primaryRepository: TransactionRepository;
+    private categoryRepository: CategoryVectorRepository;
 
-    constructor(primaryRepository: TransactionRepository) {
+    constructor(primaryRepository: TransactionRepository, categoryRepository: CategoryVectorRepository) {
         this.primaryRepository = primaryRepository;
+        this.categoryRepository = categoryRepository;
     }
 
     async execute(transaction: Transaction): Promise<void> {
+        if (transaction.category === 'uncategorised') {
+            const { category, score } = await this.categoryRepository.recommendCategory(transaction.description);
+            if (score >= 0.85) {
+                transaction.category = category;
+            }
+        }
+
         try {
             await this.primaryRepository.save(transaction);
         } catch (error) {

--- a/src/modules/transaction/domain/categoryVectorRepository.ts
+++ b/src/modules/transaction/domain/categoryVectorRepository.ts
@@ -1,0 +1,4 @@
+export interface CategoryVectorRepository {
+  recommendCategory(text: string): Promise<{ category: string; score: number }>;
+}
+

--- a/src/modules/transaction/infrastructure/dummyCategoryVectorRepository.ts
+++ b/src/modules/transaction/infrastructure/dummyCategoryVectorRepository.ts
@@ -1,0 +1,8 @@
+import { CategoryVectorRepository } from '../domain/categoryVectorRepository';
+
+export class DummyCategoryVectorRepository implements CategoryVectorRepository {
+  async recommendCategory(_: string): Promise<{ category: string; score: number }> {
+    return { category: '', score: 0 };
+  }
+}
+

--- a/src/modules/transaction/transactionModule.ts
+++ b/src/modules/transaction/transactionModule.ts
@@ -3,19 +3,28 @@ import { GetTransactionsUseCase } from './application/getTransactions';
 import { GetUserTransactionsUseCase } from './application/getUserTransactions';
 import { AnalyticsService } from './application/analyticsService';
 import { NotionRepository } from './infrastructure/notionRepository';
+import { DummyCategoryVectorRepository } from './infrastructure/dummyCategoryVectorRepository';
 import { NotionService } from '../../infrastructure/services/notionService';
 import { TransactionRepository } from './domain/transactionRepository';
+import { CategoryVectorRepository } from './domain/categoryVectorRepository';
 
 export class TransactionModule {
-  constructor(private repository: TransactionRepository) {}
+  constructor(
+    private repository: TransactionRepository,
+    private categoryRepository: CategoryVectorRepository
+  ) {}
 
   static create(notionService: NotionService): TransactionModule {
     const repository = new NotionRepository(notionService);
-    return new TransactionModule(repository);
+    const categoryRepository = new DummyCategoryVectorRepository();
+    return new TransactionModule(repository, categoryRepository);
   }
 
   getCreateTransactionUseCase(): CreateTransactionUseCase {
-    return new CreateTransactionUseCase(this.repository);
+    return new CreateTransactionUseCase(
+      this.repository,
+      this.categoryRepository
+    );
   }
 
   getGetTransactionsUseCase(): GetTransactionsUseCase {

--- a/src/utils/cosine.ts
+++ b/src/utils/cosine.ts
@@ -1,0 +1,10 @@
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * b[i], 0);
+  const magA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+  const magB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+  if (magA === 0 || magB === 0) {
+    return 0;
+  }
+  return dot / (magA * magB);
+}
+

--- a/tests/createTransaction.test.ts
+++ b/tests/createTransaction.test.ts
@@ -1,6 +1,7 @@
 import { CreateTransactionUseCase } from '../src/modules/transaction/application/createTransaction';
 import { Transaction } from '../src/modules/transaction/domain/transactionEntity';
 import { TransactionRepository } from '../src/modules/transaction/domain/transactionRepository';
+import { CategoryVectorRepository } from '../src/modules/transaction/domain/categoryVectorRepository';
 
 describe('CreateTransactionUseCase', () => {
   it('saves transaction via repository', async () => {
@@ -15,10 +16,34 @@ describe('CreateTransactionUseCase', () => {
 
     const save = jest.fn().mockResolvedValue(undefined);
     const repo: TransactionRepository = { save, getAll: jest.fn() };
+    const vectorRepo: CategoryVectorRepository = { recommendCategory: jest.fn() };
 
-    const useCase = new CreateTransactionUseCase(repo);
+    const useCase = new CreateTransactionUseCase(repo, vectorRepo);
     await useCase.execute(transaction);
 
     expect(save).toHaveBeenCalledWith(transaction);
+  });
+
+  it('overwrites uncategorised with recommended category', async () => {
+    const transaction: Transaction = {
+      date: '2024-01-01',
+      category: 'uncategorised',
+      description: 'Starbucks latte',
+      amount: 5,
+      type: 'expense',
+      userId: 'user1'
+    };
+
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo: TransactionRepository = { save, getAll: jest.fn() };
+    const vectorRepo: CategoryVectorRepository = {
+      recommendCategory: jest.fn().mockResolvedValue({ category: 'Coffee', score: 0.9 })
+    };
+
+    const useCase = new CreateTransactionUseCase(repo, vectorRepo);
+    await useCase.execute(transaction);
+
+    expect(vectorRepo.recommendCategory).toHaveBeenCalledWith('Starbucks latte');
+    expect(save).toHaveBeenCalledWith({ ...transaction, category: 'Coffee' });
   });
 });


### PR DESCRIPTION
## Summary
- inject `CategoryVectorRepository` into `CreateTransactionUseCase`
- use `recommendCategory` for uncategorised transactions
- provide dummy implementation and wire it via `TransactionModule`
- expose cosine similarity helper
- cover recommendation logic with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d157ea71083308ffdda5af04535dd