### PR TITLE
Implement category recommendation in transaction use case

### DIFF
--- a/src/appModules.ts
+++ b/src/appModules.ts
@@ -1,6 +1,8 @@
 import { OPENAI_API_KEY, NOTION_API_KEY, NOTION_DATABASE_ID } from './config';
 import { NotionService } from './infrastructure/services/notionService';
 import { TransactionModule } from './modules/transaction/transactionModule';
+import { CategoryVectorRepository } from './modules/categoryRecommendation/infrastructure/CategoryVectorRepository';
+import { OpenAIEmbeddingService } from './infrastructure/openai/OpenAIEmbeddingService';
 import { OpenAITranscriptionService } from './modules/voiceProcessing/infrastructure/openAITranscriptionService';
 import { VoiceProcessingModule } from './modules/voiceProcessing/voiceProcessingModule';
 import { OpenAIModerationService } from './infrastructure/openai/OpenAIModerationService';
@@ -8,7 +10,9 @@ import OpenAI from 'openai';
 
 export function createModules() {
   const notionService = new NotionService(NOTION_API_KEY, NOTION_DATABASE_ID);
-  const transactionModule = TransactionModule.create(notionService);
+  const embeddingService = new OpenAIEmbeddingService(OPENAI_API_KEY);
+  const categoryRepo = new CategoryVectorRepository({}, embeddingService);
+  const transactionModule = TransactionModule.create(notionService, categoryRepo);
   const openAIService = new OpenAITranscriptionService(OPENAI_API_KEY);
   const voiceModule = new VoiceProcessingModule(openAIService, transactionModule);
   const openAIClient = new OpenAI({ apiKey: OPENAI_API_KEY });

--- a/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
+++ b/src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository.ts
@@ -48,4 +48,8 @@ export class CategoryVectorRepository {
 
     return { label: bestLabel, score: bestScore };
   }
+
+  async recommendCategory(text: string): Promise<{ label: string; score: number }> {
+    return this.findNearest(text);
+  }
 }

--- a/src/modules/transaction/application/createTransaction.ts
+++ b/src/modules/transaction/application/createTransaction.ts
@@ -2,16 +2,25 @@
 
 import { Transaction } from '../domain/transactionEntity';
 import { TransactionRepository } from '../domain/transactionRepository';
+import { CategoryVectorRepository } from '../../categoryRecommendation/infrastructure/CategoryVectorRepository';
 
 export class CreateTransactionUseCase {
     private primaryRepository: TransactionRepository;
+    private categoryRepo: CategoryVectorRepository;
 
-    constructor(primaryRepository: TransactionRepository) {
+    constructor(primaryRepository: TransactionRepository, categoryRepo: CategoryVectorRepository) {
         this.primaryRepository = primaryRepository;
+        this.categoryRepo = categoryRepo;
     }
 
     async execute(transaction: Transaction): Promise<void> {
         try {
+            if (transaction.category === 'uncategorised') {
+                const { label, score } = await this.categoryRepo.recommendCategory(transaction.description);
+                if (score >= 0.85) {
+                    transaction.category = label;
+                }
+            }
             await this.primaryRepository.save(transaction);
         } catch (error) {
             console.error('Error with primary repository, falling back to secondary', error);

--- a/src/modules/transaction/transactionModule.ts
+++ b/src/modules/transaction/transactionModule.ts
@@ -5,17 +5,18 @@ import { AnalyticsService } from './application/analyticsService';
 import { NotionRepository } from './infrastructure/notionRepository';
 import { NotionService } from '../../infrastructure/services/notionService';
 import { TransactionRepository } from './domain/transactionRepository';
+import { CategoryVectorRepository } from '../categoryRecommendation/infrastructure/CategoryVectorRepository';
 
 export class TransactionModule {
-  constructor(private repository: TransactionRepository) {}
+  constructor(private repository: TransactionRepository, private categoryRepo: CategoryVectorRepository) {}
 
-  static create(notionService: NotionService): TransactionModule {
+  static create(notionService: NotionService, categoryRepo: CategoryVectorRepository): TransactionModule {
     const repository = new NotionRepository(notionService);
-    return new TransactionModule(repository);
+    return new TransactionModule(repository, categoryRepo);
   }
 
   getCreateTransactionUseCase(): CreateTransactionUseCase {
-    return new CreateTransactionUseCase(this.repository);
+    return new CreateTransactionUseCase(this.repository, this.categoryRepo);
   }
 
   getGetTransactionsUseCase(): GetTransactionsUseCase {

--- a/tests/createTransaction.test.ts
+++ b/tests/createTransaction.test.ts
@@ -1,6 +1,7 @@
 import { CreateTransactionUseCase } from '../src/modules/transaction/application/createTransaction';
 import { Transaction } from '../src/modules/transaction/domain/transactionEntity';
 import { TransactionRepository } from '../src/modules/transaction/domain/transactionRepository';
+import { CategoryVectorRepository } from '../src/modules/categoryRecommendation/infrastructure/CategoryVectorRepository';
 
 describe('CreateTransactionUseCase', () => {
   it('saves transaction via repository', async () => {
@@ -15,10 +16,33 @@ describe('CreateTransactionUseCase', () => {
 
     const save = jest.fn().mockResolvedValue(undefined);
     const repo: TransactionRepository = { save, getAll: jest.fn() };
+    const categoryRepo: CategoryVectorRepository = { recommendCategory: jest.fn() } as unknown as CategoryVectorRepository;
 
-    const useCase = new CreateTransactionUseCase(repo);
+    const useCase = new CreateTransactionUseCase(repo, categoryRepo);
     await useCase.execute(transaction);
 
     expect(save).toHaveBeenCalledWith(transaction);
+  });
+
+  it('recommends category when uncategorised', async () => {
+    const transaction: Transaction = {
+      date: '2024-01-01',
+      category: 'uncategorised',
+      description: 'Starbucks latte',
+      amount: 5,
+      type: 'expense',
+      userId: 'user1'
+    };
+
+    const save = jest.fn().mockResolvedValue(undefined);
+    const repo: TransactionRepository = { save, getAll: jest.fn() };
+    const recommendCategory = jest.fn().mockResolvedValue({ label: 'Coffee', score: 0.9 });
+    const categoryRepo: CategoryVectorRepository = { recommendCategory } as unknown as CategoryVectorRepository;
+
+    const useCase = new CreateTransactionUseCase(repo, categoryRepo);
+    await useCase.execute(transaction);
+
+    expect(recommendCategory).toHaveBeenCalledWith('Starbucks latte');
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ category: 'Coffee' }));
   });
 });


### PR DESCRIPTION
## Summary
- inject `CategoryVectorRepository` into `CreateTransactionUseCase`
- suggest category when transaction is uncategorised
- expose new method `recommendCategory`
- wire repository through `TransactionModule` and `createModules`
- test category recommendation scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d180f245c8330a99e6029556165c6