### PR TITLE
Add OpenAI chat service DI

### DIFF
--- a/src/framework/di.ts
+++ b/src/framework/di.ts
@@ -1,0 +1,15 @@
+import { OPENAI_API_KEY } from '../config';
+import { OpenAIChatService } from '../infrastructure/openai/OpenAIChatService';
+import { ChatCompletionTool } from 'openai/resources/chat';
+import { transactionSchema } from '../core/dto/TransactionDTO';
+
+const tools: ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: { name: 'createTransaction', parameters: transactionSchema }
+  }
+];
+
+export function createOpenAIChatService(): OpenAIChatService {
+  return new OpenAIChatService(OPENAI_API_KEY, tools);
+}


### PR DESCRIPTION
## Summary
- add dependency injection setup for OpenAIChatService
- register `createTransaction` function tool based on `transactionSchema`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d1999074083308d27f021181aa803