### PR TITLE
Adjust start script and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN npm run build
 EXPOSE 3000
 
 # Указываем команду для запуска приложения
-CMD ["npm", "run", "start"]
+CMD ["npm", "start"]
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "npm run build && npm run serve",
+    "start": "node dist/index.js",
     "build": "npx tsc",
     "serve": "node dist/index.js",
     "dev": "ts-node-dev src/index.ts",


### PR DESCRIPTION
## Summary
- run compiled server directly in the `start` script
- use `npm start` in the Dockerfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864bf18bf808330b3453dd3bcbe711c