### PR TITLE
Update mini app domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OPENAI_API_KEY=your_openai_key
 NOTION_API_KEY=your_notion_key
 NOTION_DATABASE_ID=your_notion_database_id
 TG_BOT_API_KEY=your_telegram_bot_key
-WEB_APP_URL=https://your-domain.com
+WEB_APP_URL=https://sapaev.uz
 ```
 
 ## Build and Run

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,5 +6,5 @@ export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
 export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
 export const TG_BOT_API_KEY = process.env.TG_BOT_API_KEY || '';
-export const WEB_APP_URL = process.env.WEB_APP_URL || '';
+export const WEB_APP_URL = process.env.WEB_APP_URL || 'https://sapaev.uz';
 


### PR DESCRIPTION
## Summary
- set default WEB_APP_URL to `https://sapaev.uz`
- update README example with the new domain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68652a8c256483309cee570db548748c