### PR TITLE
Improve Telegram bot UX and add delete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createModules } from './appModules';
 const { transactionModule, voiceModule } = createModules();
 const app = buildServer(transactionModule, voiceModule);
 const port = process.env.PORT || 3000;
-startTelegramBot(voiceModule);
+startTelegramBot(voiceModule, transactionModule);
 
 app.listen(port, () => {
     console.log(`Server running on port ${port}`);

--- a/src/infrastructure/services/notionService.ts
+++ b/src/infrastructure/services/notionService.ts
@@ -10,8 +10,8 @@ export class NotionService {
         this.databaseId = databaseId;
     }
 
-    async saveTransaction(transaction: Transaction): Promise<void> {
-        await this.notion.pages.create({
+    async saveTransaction(transaction: Transaction): Promise<string> {
+        const page = await this.notion.pages.create({
             parent: { database_id: this.databaseId },
             properties: {
                 Date: {
@@ -51,6 +51,7 @@ export class NotionService {
                 },
             },
         });
+        return (page as any).id as string;
     }
 
     async getTransactions(): Promise<Transaction[]> {
@@ -72,5 +73,9 @@ export class NotionService {
             console.log(error);
             throw new Error("Notion API Error: " + error.message);
         }
+    }
+
+    async deleteTransaction(id: string): Promise<void> {
+        await this.notion.pages.update({ page_id: id, archived: true });
     }
 }

--- a/src/modules/transaction/application/createTransaction.ts
+++ b/src/modules/transaction/application/createTransaction.ts
@@ -10,12 +10,12 @@ export class CreateTransactionUseCase {
         this.primaryRepository = primaryRepository;
     }
 
-    async execute(transaction: Transaction): Promise<void> {
+    async execute(transaction: Transaction): Promise<string> {
         try {
-            await this.primaryRepository.save(transaction);
+            return await this.primaryRepository.save(transaction);
         } catch (error) {
             console.error('Error with primary repository, falling back to secondary', error);
-            // await this.fallbackRepository.save(transaction);
+            throw error;
         }
     }
 }

--- a/src/modules/transaction/application/deleteTransaction.ts
+++ b/src/modules/transaction/application/deleteTransaction.ts
@@ -1,0 +1,10 @@
+// src/application/deleteTransaction.ts
+import { TransactionRepository } from '../domain/transactionRepository';
+
+export class DeleteTransactionUseCase {
+    constructor(private repository: TransactionRepository) {}
+
+    async execute(id: string): Promise<void> {
+        await this.repository.delete(id);
+    }
+}

--- a/src/modules/transaction/domain/transactionRepository.ts
+++ b/src/modules/transaction/domain/transactionRepository.ts
@@ -2,6 +2,7 @@
 import { Transaction } from "./transactionEntity";
 
 export interface TransactionRepository {
-    save(transaction: Transaction): Promise<void>;
+    save(transaction: Transaction): Promise<string>;
     getAll(): Promise<Transaction[]>;
+    delete(id: string): Promise<void>;
 }

--- a/src/modules/transaction/infrastructure/notionRepository.ts
+++ b/src/modules/transaction/infrastructure/notionRepository.ts
@@ -10,8 +10,8 @@ export class NotionRepository implements TransactionRepository {
         this.notionService = notionService;
     }
 
-    async save(transaction: Transaction): Promise<void> {
-        await this.notionService.saveTransaction(transaction);
+    async save(transaction: Transaction): Promise<string> {
+        return this.notionService.saveTransaction(transaction);
     }
 
     async getAll(): Promise<Transaction[]> {
@@ -21,5 +21,9 @@ export class NotionRepository implements TransactionRepository {
     async getRecentTransactions(limit: number): Promise<Transaction[]> {
         const transactions = await this.getAll();
         return transactions.slice(-limit); // Берем последние N записей
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.notionService.deleteTransaction(id);
     }
 }

--- a/src/modules/transaction/transactionModule.ts
+++ b/src/modules/transaction/transactionModule.ts
@@ -1,6 +1,7 @@
 import { CreateTransactionUseCase } from './application/createTransaction';
 import { GetTransactionsUseCase } from './application/getTransactions';
 import { GetUserTransactionsUseCase } from './application/getUserTransactions';
+import { DeleteTransactionUseCase } from './application/deleteTransaction';
 import { AnalyticsService } from './application/analyticsService';
 import { NotionRepository } from './infrastructure/notionRepository';
 import { NotionService } from '../../infrastructure/services/notionService';
@@ -24,6 +25,10 @@ export class TransactionModule {
 
   getGetUserTransactionsUseCase(): GetUserTransactionsUseCase {
     return new GetUserTransactionsUseCase(this.repository);
+  }
+
+  getDeleteTransactionUseCase(): DeleteTransactionUseCase {
+    return new DeleteTransactionUseCase(this.repository);
   }
 
   getAnalyticsService(): AnalyticsService {

--- a/src/modules/voiceProcessing/application/processTextInput.ts
+++ b/src/modules/voiceProcessing/application/processTextInput.ts
@@ -22,8 +22,8 @@ export class ProcessTextInputUseCase {
             userName,
         };
 
-        await this.createTransactionUseCase.execute(transaction);
+        const id = await this.createTransactionUseCase.execute(transaction);
 
-        return { text, amount, category, type };
+        return { text, amount, category, type, id };
     }
 }

--- a/src/modules/voiceProcessing/application/processVoiceInput.ts
+++ b/src/modules/voiceProcessing/application/processVoiceInput.ts
@@ -47,9 +47,9 @@ export class ProcessVoiceInputUseCase {
             userName: input.userName,
         };
 
-        await this.createTransactionUseCase.execute(transaction);
+        const id = await this.createTransactionUseCase.execute(transaction);
         await fs.unlink(newFilePath);
 
-        return { text: recognizedText, amount, category, type };
+        return { text: recognizedText, amount, category, type, id };
     }
 }

--- a/src/modules/voiceProcessing/domain/processedTransaction.ts
+++ b/src/modules/voiceProcessing/domain/processedTransaction.ts
@@ -3,4 +3,5 @@ export interface ProcessedTransaction {
     amount: number;
     category: string;
     type: 'income' | 'expense';
+    id: string;
 }

--- a/tests/createTransaction.test.ts
+++ b/tests/createTransaction.test.ts
@@ -13,12 +13,13 @@ describe('CreateTransactionUseCase', () => {
       userId: 'user1'
     };
 
-    const save = jest.fn().mockResolvedValue(undefined);
-    const repo: TransactionRepository = { save, getAll: jest.fn() };
+    const save = jest.fn().mockResolvedValue('1');
+    const repo: TransactionRepository = { save, getAll: jest.fn(), delete: jest.fn() } as any;
 
     const useCase = new CreateTransactionUseCase(repo);
-    await useCase.execute(transaction);
+    const id = await useCase.execute(transaction);
 
     expect(save).toHaveBeenCalledWith(transaction);
+    expect(id).toBe('1');
   });
 });

--- a/tests/getTransactions.test.ts
+++ b/tests/getTransactions.test.ts
@@ -8,7 +8,7 @@ describe('GetTransactionsUseCase', () => {
       { date: '2024-01-01', category: 'Food', description: 'Lunch', amount: 10, type: 'expense', userId: 'user1' }
     ];
 
-    const repo: TransactionRepository = { save: jest.fn(), getAll: jest.fn().mockResolvedValue(data) };
+    const repo: TransactionRepository = { save: jest.fn(), getAll: jest.fn().mockResolvedValue(data), delete: jest.fn() } as any;
 
     const useCase = new GetTransactionsUseCase(repo);
     const result = await useCase.execute();

--- a/tests/getUserTransactions.test.ts
+++ b/tests/getUserTransactions.test.ts
@@ -9,7 +9,7 @@ describe('GetUserTransactionsUseCase', () => {
       { date: '2024-01-02', category: 'Books', description: 'Book', amount: 20, type: 'expense', userId: 'u2' }
     ];
 
-    const repo: TransactionRepository = { save: jest.fn(), getAll: jest.fn().mockResolvedValue(data) };
+    const repo: TransactionRepository = { save: jest.fn(), getAll: jest.fn().mockResolvedValue(data), delete: jest.fn() } as any;
 
     const useCase = new GetUserTransactionsUseCase(repo);
     const result = await useCase.execute('u1');

--- a/tests/processTextInput.test.ts
+++ b/tests/processTextInput.test.ts
@@ -12,13 +12,13 @@ describe('ProcessTextInputUseCase', () => {
     } as unknown as TranscriptionService;
 
     const createTransactionUseCase = {
-      execute: jest.fn()
+      execute: jest.fn().mockResolvedValue('42')
     } as unknown as CreateTransactionUseCase;
 
     const useCase = new ProcessTextInputUseCase(openAIService, createTransactionUseCase);
     const result = await useCase.execute('test', 'user1');
 
     expect(createTransactionUseCase.execute).toHaveBeenCalled();
-    expect(result).toEqual({ text: 'test', amount: 5, category: 'Food', type: 'expense' });
+    expect(result).toEqual({ text: 'test', amount: 5, category: 'Food', type: 'expense', id: '42' });
   });
 });


### PR DESCRIPTION
## Summary
- allow retrieving page id from Notion and add delete method
- introduce DeleteTransactionUseCase and expose from module
- extend processed transaction data with ID
- modify voice and text processing use cases to return transaction ID
- improve Telegram bot with mini app link and delete button
- update tests for new interfaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661b28e188833089b78329e62b969f