### PR TITLE
Fix Telegram inline keyboard removal

### DIFF
--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -113,7 +113,8 @@ export function startTelegramBot(
     try {
       await deleteUseCase.execute(id);
       lastTx[userId] = '';
-      await ctx.editMessageReplyMarkup();
+      // Remove inline keyboard after deletion
+      await ctx.editMessageReplyMarkup(undefined);
       await ctx.answerCbQuery('Deleted');
     } catch (err) {
       console.error('Error deleting transaction:', err);


### PR DESCRIPTION
## Summary
- add a comment clarifying that we pass `undefined` to remove inline keyboards

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68663481fd448330bc82b75b9d68e3a2