### PR TITLE
Configure API prefix and serve webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ docker compose down
 ## Web App (Telegram Mini App)
 
 The `webapp/` folder contains a React + TypeScript frontend built with Vite. It
-is served by Express from the `/webapp` route.
+is served by Express at the root path, while the backend API is available under
+the `/api` prefix.
 
 ### Development
 

--- a/src/framework/express/expressServer.ts
+++ b/src/framework/express/expressServer.ts
@@ -15,15 +15,9 @@ export function buildServer(
   app.use(bodyParser.json());
   app.use(cors<Request>());
 
-  // Serve static files for the Telegram web app.
-  // __dirname points to "src/framework/express" in development and
-  // "dist/framework/express" in production. We go three levels up to
-  // reach the project root, then into "public/webapp".
-  const webappDir = path.join(__dirname, '../../../public/webapp');
-  app.use('/webapp', express.static(webappDir));
+  const apiRouter = express.Router();
 
-
-  app.use(
+  apiRouter.use(
     '/transactions',
     createTransactionRouter(
       transactionModule.getCreateTransactionUseCase(),
@@ -33,13 +27,26 @@ export function buildServer(
     )
   );
 
-  app.use(
+  apiRouter.use(
     '/voice',
     createVoiceProcessingRouter(
       voiceModule.getProcessVoiceInputUseCase(),
       voiceModule.getProcessTextInputUseCase()
     )
   );
+
+
+  app.use('/api', apiRouter);
+
+  // Serve the React web app from the root path. __dirname points to
+  // "src/framework/express" in development and "dist/framework/express" in
+  // production. We go three levels up to reach the project root, then into
+  // "public/webapp".
+  const webappDir = path.join(__dirname, '../../../public/webapp');
+  app.use(express.static(webappDir));
+  app.get('*', (_, res) => {
+    res.sendFile(path.join(webappDir, 'index.html'));
+  });
 
   return app;
 }


### PR DESCRIPTION
## Summary
- serve React app from the root path
- mount backend routes under `/api`
- update README with new routing info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866790cafd48330a305b486c9093cea