### PR TITLE
Improve env loading checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ TG_BOT_API_KEY=your_telegram_bot_key
 WEB_APP_URL=https://sapaev.uz
 ```
 
+When the server starts, it prints a warning if the `.env` file is missing or any
+required variables are undefined. `NOTION_API_KEY` and `NOTION_DATABASE_ID` are
+mandatory and the server will stop with a descriptive error if they are not
+provided.
+
 ## Build and Run
 
 To compile the TypeScript sources and start the application:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,11 @@
 import dotenv from 'dotenv';
 
-dotenv.config();
+const result = dotenv.config();
+if (result.error) {
+  console.warn('.env file not found');
+} else {
+  console.log('Environment variables loaded');
+}
 
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
@@ -8,3 +13,12 @@ export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
 export const TG_BOT_API_KEY = process.env.TG_BOT_API_KEY || '';
 export const WEB_APP_URL = process.env.WEB_APP_URL || 'https://sapaev.uz';
 
+export function validateEnv() {
+  const missing: string[] = [];
+  if (!OPENAI_API_KEY) missing.push('OPENAI_API_KEY');
+  if (!NOTION_API_KEY) missing.push('NOTION_API_KEY');
+  if (!NOTION_DATABASE_ID) missing.push('NOTION_DATABASE_ID');
+  if (missing.length) {
+    console.warn(`Missing environment variables: ${missing.join(', ')}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
-import './config';
+import { validateEnv } from './config';
 import express from 'express';
 import path from 'path';
 import { buildServer } from './framework/express/expressServer';
 import { startTelegramBot } from './framework/telegram/telegramBot';
 import { createModules } from './appModules';
+
+validateEnv();
 
 const { transactionModule, voiceModule } = createModules();
 const app = express();

--- a/src/infrastructure/services/notionService.ts
+++ b/src/infrastructure/services/notionService.ts
@@ -6,6 +6,12 @@ export class NotionService {
     private databaseId: string;
 
     constructor(apiKey: string, databaseId: string) {
+        if (!apiKey) {
+            throw new Error('NOTION_API_KEY is not set');
+        }
+        if (!databaseId) {
+            throw new Error('NOTION_DATABASE_ID is not set');
+        }
         this.notion = new Client({ auth: apiKey });
         this.databaseId = databaseId;
     }


### PR DESCRIPTION
## Summary
- warn when .env file is missing or variables are undefined
- add validateEnv() and call it during startup
- document env validation behavior in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d1cf5e24c83309c14791b37958792