### PR TITLE
Add env file example and docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=your_openai_key
+NOTION_API_KEY=your_notion_key
+NOTION_DATABASE_ID=your_notion_database_id
+TG_BOT_API_KEY=your_telegram_bot_key
+WEB_APP_URL=https://sapaev.uz

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project provides a simple backend service written in TypeScript for trackin
 npm install
 ```
 
-2. Create a `.env` file in the project root and define the following variables:
+2. Copy `.env.example` to `.env` in the project root and define the following variables:
 
 ```
 OPENAI_API_KEY=your_openai_key
@@ -53,6 +53,8 @@ To build and start the application in a container:
 ```bash
 docker compose up -d --build
 ```
+
+Docker Compose loads environment variables from `.env`, so make sure to create it first (you can copy from `.env.example`).
 
 The service will be available on [http://localhost:3000](http://localhost:3000).
 View logs with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,6 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
+    env_file:
+      - .env
     command: npm start


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder values
- mount `.env` in docker-compose
- update README instructions about `.env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d20e59f688330be57b2551894daf7