### PR TITLE
Fix asset path for webapp

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/webapp/',
   build: {
     outDir: '../public/webapp',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- ensure Vite builds the app with the `/webapp/` base so assets load correctly under Express

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d2ce388b88330a65d95723683666f