### PR TITLE
Add navigation links between pages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@ node_modules
 npm-debug.log
 dist
 webapp/node_modules
-webapp/build
+public/webapp

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 node_modules/
 dist/
 webapp/node_modules/
-webapp/build/
-public/webapp/index.html
-public/webapp/assets/
+public/webapp/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cd webapp
 npm run build
 ```
 
-The build outputs static files to `webapp/build/` so they can be served by the
+The build outputs static files to `public/webapp/` so they can be served by the
 backend.
 
 ## Running Tests

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -13,7 +13,15 @@ export default function App() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold">FinTrack WebApp</h1>
+      <h1 className="text-xl font-bold mb-4">FinTrack WebApp</h1>
+      <nav className="space-x-4">
+        <a className="text-blue-600 underline" href="/webapp/transactions.html">
+          Transactions
+        </a>
+        <a className="text-blue-600 underline" href="/webapp/stats.html">
+          Stats
+        </a>
+      </nav>
     </div>
   );
 }

--- a/webapp/src/StatsApp.tsx
+++ b/webapp/src/StatsApp.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+
+interface Transaction {
+  date: string;
+  category: string;
+  description: string;
+  amount: number;
+  type: 'income' | 'expense';
+  userId: string;
+  userName?: string;
+}
+
+type Month = { month: number; year: number };
+
+export default function StatsApp() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [months, setMonths] = useState<Month[]>([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const userId = params.get('userId');
+    if (!userId) {
+      setLoading(false);
+      return;
+    }
+
+    fetch(`/api/transactions/user/${userId}`)
+      .then(res => res.json())
+      .then(data => {
+        setTransactions(data);
+        const setMonth = new Set(
+          data.map((t: Transaction) => {
+            const d = new Date(t.date);
+            return `${d.getFullYear()}-${d.getMonth()}`;
+          })
+        );
+        const list = Array.from(setMonth)
+          .map(str => {
+            const [y, m] = str.split('-').map(Number);
+            return { year: y, month: m } as Month;
+          })
+          .sort((a, b) =>
+            a.year === b.year ? a.month - b.month : a.year - b.year
+          );
+        setMonths(list);
+        setIndex(list.length > 0 ? list.length - 1 : 0);
+      })
+      .catch(err => console.error('Failed to fetch transactions', err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const calcSum = (items: Transaction[]) =>
+    items.reduce(
+      (sum, t) => sum + (t.type === 'expense' ? -t.amount : t.amount),
+      0
+    );
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const total = calcSum(transactions);
+
+  let monthLabel = '-';
+  let monthSum = 0;
+  if (months.length > 0) {
+    const { year, month } = months[index];
+    const filtered = transactions.filter(t => {
+      const d = new Date(t.date);
+      return d.getFullYear() === year && d.getMonth() === month;
+    });
+    monthSum = calcSum(filtered);
+    monthLabel = new Date(year, month).toLocaleString('default', {
+      month: 'long',
+      year: 'numeric'
+    });
+  }
+
+  const prev = () => setIndex(i => (i > 0 ? i - 1 : i));
+  const next = () => setIndex(i => (i < months.length - 1 ? i + 1 : i));
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Statistics</h1>
+      <nav className="mb-4">
+        <a className="text-blue-600 underline" href="/webapp/transactions.html">
+          Back to Transactions
+        </a>
+      </nav>
+      <div className="border rounded p-4 mb-4">
+        <div className="text-sm text-gray-500">Total</div>
+        <div className="text-lg font-semibold">{total}</div>
+      </div>
+      <div className="border rounded p-4">
+        <div className="flex items-center justify-between mb-2">
+          <button className="px-2" onClick={prev}>&lt;</button>
+          <span>{monthLabel}</span>
+          <button className="px-2" onClick={next}>&gt;</button>
+        </div>
+        <div className="text-lg font-semibold">{monthSum}</div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/TransactionsApp.tsx
+++ b/webapp/src/TransactionsApp.tsx
@@ -36,6 +36,11 @@ export default function TransactionsApp() {
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Transactions</h1>
+      <nav className="mb-4">
+        <a className="text-blue-600 underline" href="/webapp/stats.html">
+          View Stats
+        </a>
+      </nav>
       {transactions.length === 0 ? (
         <p>No transactions found.</p>
       ) : (

--- a/webapp/src/stats.tsx
+++ b/webapp/src/stats.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import StatsApp from './StatsApp';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <StatsApp />
+  </React.StrictMode>
+);

--- a/webapp/stats.html
+++ b/webapp/stats.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <title>FinTrack Stats</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/stats.tsx"></script>
+  </body>
+</html>

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),
-        transactions: resolve(__dirname, 'transactions.html')
+        transactions: resolve(__dirname, 'transactions.html'),
+        stats: resolve(__dirname, 'stats.html')
       }
     }
   },


### PR DESCRIPTION
## Summary
- link transactions and stats pages from the home screen
- add links between transactions and stats pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d4731468883308fbd5c04b72992b4