### PR TITLE
Fix userId persistence in webapp

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <title>FinTrack WebApp</title>
   </head>
-  <body>
+  <body class="bg-white">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -11,14 +11,24 @@ export default function App() {
     window.Telegram?.WebApp?.ready();
   }, []);
 
+  const params = new URLSearchParams(window.location.search);
+  const userId = params.get('userId');
+  const query = userId ? `?userId=${userId}` : '';
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">FinTrack WebApp</h1>
       <nav className="space-x-4">
-        <a className="text-blue-600 underline" href="/webapp/transactions.html">
+        <a
+          className="text-blue-600 underline"
+          href={`/webapp/transactions.html${query}`}
+        >
           Transactions
         </a>
-        <a className="text-blue-600 underline" href="/webapp/stats.html">
+        <a
+          className="text-blue-600 underline"
+          href={`/webapp/stats.html${query}`}
+        >
           Stats
         </a>
       </nav>

--- a/webapp/src/StatsApp.tsx
+++ b/webapp/src/StatsApp.tsx
@@ -17,16 +17,16 @@ export default function StatsApp() {
   const [loading, setLoading] = useState(true);
   const [months, setMonths] = useState<Month[]>([]);
   const [index, setIndex] = useState(0);
+  const params = new URLSearchParams(window.location.search);
+  const userIdParam = params.get('userId');
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const userId = params.get('userId');
-    if (!userId) {
+    if (!userIdParam) {
       setLoading(false);
       return;
     }
 
-    fetch(`/api/transactions/user/${userId}`)
+    fetch(`/api/transactions/user/${userIdParam}`)
       .then(res => res.json())
       .then(data => {
         setTransactions(data);
@@ -85,7 +85,10 @@ export default function StatsApp() {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Statistics</h1>
       <nav className="mb-4">
-        <a className="text-blue-600 underline" href="/webapp/transactions.html">
+        <a
+          className="text-blue-600 underline"
+          href={`/webapp/transactions.html${userIdParam ? `?userId=${userIdParam}` : ''}`}
+        >
           Back to Transactions
         </a>
       </nav>

--- a/webapp/src/TransactionsApp.tsx
+++ b/webapp/src/TransactionsApp.tsx
@@ -13,16 +13,16 @@ interface Transaction {
 export default function TransactionsApp() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const params = new URLSearchParams(window.location.search);
+  const userIdParam = params.get('userId');
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const userId = params.get('userId');
-    if (!userId) {
+    if (!userIdParam) {
       setLoading(false);
       return;
     }
 
-    fetch(`/api/transactions/user/${userId}`)
+    fetch(`/api/transactions/user/${userIdParam}`)
       .then(res => res.json())
       .then(data => setTransactions(data))
       .catch(err => console.error('Failed to fetch transactions', err))
@@ -37,7 +37,10 @@ export default function TransactionsApp() {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Transactions</h1>
       <nav className="mb-4">
-        <a className="text-blue-600 underline" href="/webapp/stats.html">
+        <a
+          className="text-blue-600 underline"
+          href={`/webapp/stats.html${userIdParam ? `?userId=${userIdParam}` : ''}`}
+        >
           View Stats
         </a>
       </nav>

--- a/webapp/stats.html
+++ b/webapp/stats.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <title>FinTrack Stats</title>
   </head>
-  <body>
+  <body class="bg-white">
     <div id="root"></div>
     <script type="module" src="/src/stats.tsx"></script>
   </body>

--- a/webapp/transactions.html
+++ b/webapp/transactions.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <title>FinTrack Transactions</title>
   </head>
-  <body>
+  <body class="bg-white">
     <div id="root"></div>
     <script type="module" src="/src/transactions.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- keep the `userId` query param when navigating between pages
- set white background for webapp pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d5336296c833080be4b6933e1d98e