### PR TITLE
Improve amount formatting

### DIFF
--- a/public/webapp/transactions.html
+++ b/public/webapp/transactions.html
@@ -19,12 +19,13 @@
       const res = await fetch(`/api/transactions/user/${userId}`);
       const data = await res.json();
       const list = document.getElementById('list');
+      const fmt = new Intl.NumberFormat('ru-RU');
       data.forEach(t => {
         const el = document.createElement('div');
         el.className = 'bg-white p-3 rounded shadow';
         el.innerHTML = `<div class="text-sm text-gray-500">${t.date} - ${t.category}</div>` +
                        `<div class="font-medium">${t.description}</div>` +
-                       `<div class="text-right">${t.amount}</div>`;
+                       `<div class="text-right">${fmt.format(t.amount)}</div>`;
         list.appendChild(el);
       });
       window.Telegram?.WebApp?.ready();

--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -29,6 +29,7 @@ export function startTelegramBot(
 
   const bot = new Telegraf(TG_BOT_API_KEY);
   const deleteUseCase = transactionModule.getDeleteTransactionUseCase();
+  const fmt = new Intl.NumberFormat('ru-RU');
   const lastTx: Record<string, string> = {};
 
   bot.start(async ctx => {
@@ -66,7 +67,7 @@ export function startTelegramBot(
       lastTx[userId] = result.id;
       const url = WEB_APP_URL ? `${WEB_APP_URL}/webapp/transactions.html?userId=${userId}` : undefined;
       await ctx.reply(
-        `Saved: ${result.text}\nAmount: ${result.amount}\nCategory: ${result.category}\nType: ${result.type}`,
+        `Saved: ${result.text}\nAmount: ${fmt.format(result.amount)}\nCategory: ${result.category}\nType: ${result.type}`,
         Markup.inlineKeyboard([
           [Markup.button.callback('Delete', `delete:${result.id}`)],
           ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])
@@ -89,7 +90,7 @@ export function startTelegramBot(
       lastTx[userId] = result.id;
       const url = WEB_APP_URL ? `${WEB_APP_URL}/webapp/transactions.html?userId=${userId}` : undefined;
       await ctx.reply(
-        `Saved: ${result.text}\nAmount: ${result.amount}\nCategory: ${result.category}\nType: ${result.type}`,
+        `Saved: ${result.text}\nAmount: ${fmt.format(result.amount)}\nCategory: ${result.category}\nType: ${result.type}`,
         Markup.inlineKeyboard([
           [Markup.button.callback('Delete', `delete:${result.id}`)],
           ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])

--- a/webapp/src/StatsApp.tsx
+++ b/webapp/src/StatsApp.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { formatAmount } from './utils';
 
 interface Transaction {
   date: string;
@@ -94,7 +95,7 @@ export default function StatsApp() {
       </nav>
       <div className="border rounded p-4 mb-4">
         <div className="text-sm text-gray-500">Total</div>
-        <div className="text-lg font-semibold">{total}</div>
+        <div className="text-lg font-semibold">{formatAmount(total)}</div>
       </div>
       <div className="border rounded p-4">
         <div className="flex items-center justify-between mb-2">
@@ -102,7 +103,7 @@ export default function StatsApp() {
           <span>{monthLabel}</span>
           <button className="px-2" onClick={next}>&gt;</button>
         </div>
-        <div className="text-lg font-semibold">{monthSum}</div>
+        <div className="text-lg font-semibold">{formatAmount(monthSum)}</div>
       </div>
     </div>
   );

--- a/webapp/src/TransactionsApp.tsx
+++ b/webapp/src/TransactionsApp.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { formatAmount } from './utils';
 
 interface Transaction {
   date: string;
@@ -53,7 +54,7 @@ export default function TransactionsApp() {
               <div className="text-sm text-gray-500">{new Date(tx.date).toLocaleDateString()}</div>
               <div className="font-semibold">{tx.category}</div>
               <div>{tx.description}</div>
-              <div>{tx.amount}</div>
+              <div>{formatAmount(tx.amount)}</div>
               <div className="text-sm text-gray-600">{tx.type}</div>
             </li>
           ))}

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,0 +1,2 @@
+export const formatAmount = (value: number): string =>
+  new Intl.NumberFormat('ru-RU').format(value);


### PR DESCRIPTION
## Summary
- format amounts with spaces in Telegram bot messages
- display amounts with spaces on the web

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e0727bd60833098a6a131e725fbce