### PR TITLE
Improve voice transaction parsing

### DIFF
--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -64,15 +64,17 @@ export function startTelegramBot(
     const text = ctx.message.text;
     try {
       const result = await voiceModule.getProcessTextInputUseCase().execute(text, userId, userName);
-      lastTx[userId] = result.id;
       const url = WEB_APP_URL ? `${WEB_APP_URL}/webapp/transactions.html?userId=${userId}` : undefined;
-      await ctx.reply(
-        `Saved: ${result.text}\nAmount: ${fmt.format(result.amount)}\nCategory: ${result.category}\nType: ${result.type}`,
-        Markup.inlineKeyboard([
-          [Markup.button.callback('Delete', `delete:${result.id}`)],
-          ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])
-        ])
-      );
+      for (const tx of result.transactions) {
+        lastTx[userId] = tx.id;
+        await ctx.reply(
+          `Saved: ${result.text}\nAmount: ${fmt.format(tx.amount)}\nCategory: ${tx.category}\nType: ${tx.type}`,
+          Markup.inlineKeyboard([
+            [Markup.button.callback('Delete', `delete:${tx.id}`)],
+            ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])
+          ])
+        );
+      }
     } catch (err) {
       console.error('Error handling text message:', err);
       await ctx.reply('Failed to process message');
@@ -87,15 +89,17 @@ export function startTelegramBot(
     try {
       await downloadFile(fileLink.href, filePath);
       const result = await voiceModule.getProcessVoiceInputUseCase().execute({ filePath, userId, userName });
-      lastTx[userId] = result.id;
       const url = WEB_APP_URL ? `${WEB_APP_URL}/webapp/transactions.html?userId=${userId}` : undefined;
-      await ctx.reply(
-        `Saved: ${result.text}\nAmount: ${fmt.format(result.amount)}\nCategory: ${result.category}\nType: ${result.type}`,
-        Markup.inlineKeyboard([
-          [Markup.button.callback('Delete', `delete:${result.id}`)],
-          ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])
-        ])
-      );
+      for (const tx of result.transactions) {
+        lastTx[userId] = tx.id;
+        await ctx.reply(
+          `Saved: ${result.text}\nAmount: ${fmt.format(tx.amount)}\nCategory: ${tx.category}\nType: ${tx.type}`,
+          Markup.inlineKeyboard([
+            [Markup.button.callback('Delete', `delete:${tx.id}`)],
+            ...(url ? [[Markup.button.webApp('Open app', url)] ] : [])
+          ])
+        );
+      }
     } catch (err) {
       console.error('Error handling voice message:', err);
       await ctx.reply('Failed to process voice message');

--- a/src/modules/voiceProcessing/domain/processedTransaction.ts
+++ b/src/modules/voiceProcessing/domain/processedTransaction.ts
@@ -1,7 +1,12 @@
-export interface ProcessedTransaction {
-    text: string;
+export interface DetectedTransaction {
+    id: string;
     amount: number;
     category: string;
     type: 'income' | 'expense';
-    id: string;
+    date: string;
+}
+
+export interface ProcessedTransaction {
+    text: string;
+    transactions: DetectedTransaction[];
 }

--- a/src/modules/voiceProcessing/domain/transcriptionService.ts
+++ b/src/modules/voiceProcessing/domain/transcriptionService.ts
@@ -1,4 +1,4 @@
 export interface TranscriptionService {
   transcribe(filePath: string): Promise<string>;
-  analyzeText(text: string): Promise<{ amount: number; category: string; type: 'income' | 'expense' }>;
+  analyzeTransactions(text: string): Promise<{ amount: number; category: string; type: 'income' | 'expense'; date: string }[]>;
 }

--- a/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
+++ b/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
@@ -22,16 +22,12 @@ export class OpenAITranscriptionService implements TranscriptionService {
         return response.text;
     }
 
-    async analyzeText(text: string): Promise<{ amount: number; category: string; type: 'income' | 'expense' }> {
+    async analyzeTransactions(text: string): Promise<{ amount: number; category: string; type: 'income' | 'expense'; date: string }[]> {
+        const today = new Date().toISOString().split('T')[0];
         const messages: ChatCompletionMessageParam[] = [
-            { role: 'system', content: 'Ты финансовый ассистент. Всегда возвращай ответ в формате JSON.' },
-            { role: 'user', content: `Проанализируй текст и извлеки сумму, категорию и тип транзакции.
-                Если текст содержит слова, связанные с доходами ("заработал", "получил", "перевели"), тип должен быть "income".
-                Если текст содержит слова, связанные с расходами ("купил", "заплатил", "потратил"), тип должен быть "expense".
-                Пример текста: "Мне перевели 5000 рублей за фриланс".
-                Ответ в формате JSON: {"amount": 5000, "category": "Работа", "type": "income"}.
-                Текст: "${text}"
-            ` }
+            { role: 'system', content: 'Ты финансовый ассистент. Сегодня ' + today + '. Всегда возвращай ответ в формате JSON.' },
+            { role: 'user', content: `Проанализируй текст и извлеки все транзакции. Каждая транзакция должна содержать сумму, категорию, тип (income или expense) и дату в формате ISO. Если встречаются слова вроде "вчера" или "позавчера", вычисли фактическую дату относительно сегодняшнего дня.` },
+            { role: 'user', content: text }
         ];
 
         const response = await this.openai.chat.completions.create({

--- a/tests/processTextInput.test.ts
+++ b/tests/processTextInput.test.ts
@@ -7,7 +7,7 @@ jest.mock('../src/modules/voiceProcessing/infrastructure/openAITranscriptionServ
 describe('ProcessTextInputUseCase', () => {
   it('creates transaction from text analysis', async () => {
     const openAIService = {
-      analyzeText: jest.fn().mockResolvedValue({ amount: 5, category: 'Food', type: 'expense' }),
+      analyzeTransactions: jest.fn().mockResolvedValue([{ amount: 5, category: 'Food', type: 'expense', date: '2024-01-01' }]),
       transcribe: jest.fn()
     } as unknown as TranscriptionService;
 
@@ -19,6 +19,6 @@ describe('ProcessTextInputUseCase', () => {
     const result = await useCase.execute('test', 'user1');
 
     expect(createTransactionUseCase.execute).toHaveBeenCalled();
-    expect(result).toEqual({ text: 'test', amount: 5, category: 'Food', type: 'expense', id: '42' });
+    expect(result).toEqual({ text: 'test', transactions: [{ id: '42', amount: 5, category: 'Food', type: 'expense', date: '2024-01-01' }] });
   });
 });


### PR DESCRIPTION
## Summary
- allow multiple transactions in one message
- return detected transactions with dates
- update telegram bot to handle multiple transaction results

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e590997a48330af290f3b38771371