### PR TITLE
Fix voice download directory

### DIFF
--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -8,6 +8,8 @@ import { TransactionModule } from '../../modules/transaction/transactionModule';
 
 function downloadFile(url: string, dest: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    const dir = path.dirname(dest);
+    fs.mkdirSync(dir, { recursive: true });
     const file = fs.createWriteStream(dest);
     https.get(url, response => {
       response.pipe(file);


### PR DESCRIPTION
## Summary
- ensure the download directory exists before saving voice files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f571334b08330865372f4dbac6281