### PR TITLE
Fix telegram file download handling

### DIFF
--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -11,12 +11,15 @@ function downloadFile(url: string, dest: string): Promise<string> {
     const dir = path.dirname(dest);
     fs.mkdirSync(dir, { recursive: true });
     const file = fs.createWriteStream(dest);
-    https.get(url, response => {
-      response.pipe(file);
-      file.on('finish', () => file.close(() => resolve(dest)));
-    }).on('error', err => {
-      fs.unlink(dest, () => reject(err));
-    });
+    file.on('error', err => reject(err));
+    https
+      .get(url, response => {
+        response.pipe(file);
+        file.on('finish', () => file.close(() => resolve(dest)));
+      })
+      .on('error', err => {
+        fs.unlink(dest, () => reject(err));
+      });
   });
 }
 


### PR DESCRIPTION
## Summary
- add error listener to `downloadFile` in telegram bot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f5a1086688330ade3f4c1459c2e1e