### PR TITLE
Fix env loading and downloads path

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,10 +1,17 @@
 import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
 
-const result = dotenv.config();
-if (result.error) {
-  console.warn('.env file not found');
+const envPath = path.resolve(process.cwd(), '.env');
+if (fs.existsSync(envPath)) {
+  const result = dotenv.config({ path: envPath });
+  if (result.error) {
+    console.warn('Failed to load .env file');
+  } else {
+    console.log('Environment variables loaded');
+  }
 } else {
-  console.log('Environment variables loaded');
+  console.warn('.env file not found, using environment variables');
 }
 
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
@@ -12,6 +19,7 @@ export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
 export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
 export const TG_BOT_API_KEY = process.env.TG_BOT_API_KEY || '';
 export const WEB_APP_URL = process.env.WEB_APP_URL || 'https://sapaev.uz';
+export const DOWNLOADS_DIR = process.env.DOWNLOADS_DIR || path.join(process.cwd(), 'downloads');
 
 export function validateEnv() {
   const missing: string[] = [];

--- a/src/framework/telegram/telegramBot.ts
+++ b/src/framework/telegram/telegramBot.ts
@@ -2,7 +2,7 @@ import { Telegraf, Markup } from 'telegraf';
 import fs from 'fs';
 import https from 'https';
 import path from 'path';
-import { TG_BOT_API_KEY, WEB_APP_URL } from '../../config';
+import { TG_BOT_API_KEY, WEB_APP_URL, DOWNLOADS_DIR } from '../../config';
 import { VoiceProcessingModule } from '../../modules/voiceProcessing/voiceProcessingModule';
 import { TransactionModule } from '../../modules/transaction/transactionModule';
 
@@ -36,6 +36,9 @@ export function startTelegramBot(
   const deleteUseCase = transactionModule.getDeleteTransactionUseCase();
   const fmt = new Intl.NumberFormat('ru-RU');
   const lastTx: Record<string, string> = {};
+
+  // Ensure downloads directory exists
+  fs.mkdirSync(DOWNLOADS_DIR, { recursive: true });
 
   bot.start(async ctx => {
     if (!WEB_APP_URL) {
@@ -90,10 +93,10 @@ export function startTelegramBot(
     const userId = String(ctx.from?.id ?? 'unknown');
     const userName = ctx.from?.first_name + ' ' + ctx.from?.last_name + ' ' + ctx.from?.username;
     const fileLink = await ctx.telegram.getFileLink(ctx.message.voice.file_id);
-    if (!fs.existsSync('downloads')) {
-      fs.mkdirSync('downloads');
+    if (!fs.existsSync(DOWNLOADS_DIR)) {
+      fs.mkdirSync(DOWNLOADS_DIR, { recursive: true });
     }
-    const filePath = path.join('downloads', ctx.message.voice.file_id);
+    const filePath = path.join(DOWNLOADS_DIR, ctx.message.voice.file_id);
     try {
       await downloadFile(fileLink.href, filePath);
       const result = await voiceModule.getProcessVoiceInputUseCase().execute({ filePath, userId, userName });


### PR DESCRIPTION
## Summary
- handle missing `.env` more gracefully
- make downloads directory configurable and ensure it exists

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f63a152fc8330afe79e36df214bda