### PR TITLE
Improve text parsing for multiple transactions

### DIFF
--- a/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
+++ b/src/modules/voiceProcessing/infrastructure/openAITranscriptionService.ts
@@ -25,15 +25,21 @@ export class OpenAITranscriptionService implements TranscriptionService {
     async analyzeTransactions(text: string): Promise<{ amount: number; category: string; type: 'income' | 'expense'; date: string }[]> {
         const today = new Date().toISOString().split('T')[0];
         const messages: ChatCompletionMessageParam[] = [
-            { role: 'system', content: 'Ты финансовый ассистент. Сегодня ' + today + '. Всегда возвращай ответ в формате JSON.' },
-            { role: 'user', content: `Проанализируй текст и извлеки все транзакции. Каждая транзакция должна содержать сумму, категорию, тип (income или expense) и дату в формате ISO. Если встречаются слова вроде "вчера" или "позавчера", вычисли фактическую дату относительно сегодняшнего дня.` },
+            { role: 'system', content: 'Ты финансовый ассистент. Сегодня ' + today + '. Всегда отвечай валидным JSON.' },
+            {
+                role: 'user',
+                content:
+                    'Проанализируй текст и извлеки каждую отдельную транзакцию. ' +
+                    'Верни массив объектов формата {"amount": число, "category": строка, ' +
+                    '"type": "income" | "expense", "date": "YYYY-MM-DD"}. ' +
+                    'Если встречаются слова вроде "вчера" или "позавчера", вычисли фактическую дату относительно сегодняшнего дня.'
+            },
             { role: 'user', content: text }
         ];
 
         const response = await this.openai.chat.completions.create({
             model: 'gpt-4-turbo',
             messages,
-            response_format: { type: 'json_object' },
         });
 
         if (!response.choices[0].message.content) {

--- a/tests/processTextInput.test.ts
+++ b/tests/processTextInput.test.ts
@@ -21,4 +21,33 @@ describe('ProcessTextInputUseCase', () => {
     expect(createTransactionUseCase.execute).toHaveBeenCalled();
     expect(result).toEqual({ text: 'test', transactions: [{ id: '42', amount: 5, category: 'Food', type: 'expense', date: '2024-01-01' }] });
   });
+
+  it('creates multiple transactions when text has more than one entry', async () => {
+    const openAIService = {
+      analyzeTransactions: jest.fn().mockResolvedValue([
+        { amount: 5, category: 'Food', type: 'expense', date: '2024-01-01' },
+        { amount: 40, category: 'Debt', type: 'expense', date: '2024-01-01' }
+      ]),
+      transcribe: jest.fn()
+    } as unknown as TranscriptionService;
+
+    const createTransactionUseCase = {
+      execute: jest
+        .fn()
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('2')
+    } as unknown as CreateTransactionUseCase;
+
+    const useCase = new ProcessTextInputUseCase(openAIService, createTransactionUseCase);
+    const result = await useCase.execute('text', 'user1');
+
+    expect(createTransactionUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      text: 'text',
+      transactions: [
+        { id: '1', amount: 5, category: 'Food', type: 'expense', date: '2024-01-01' },
+        { id: '2', amount: 40, category: 'Debt', type: 'expense', date: '2024-01-01' }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure OpenAI prompt requests an array of transactions
- test parsing of multiple transactions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fa7464c08833098086c363917aa37